### PR TITLE
FIX: Fix alignment to enable SSE2 for dSFMT

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,8 @@ build_script:
 
 test_script:
   - cd ..
-  - nosetests randomstate
+  - python -c "import randomstate.prng.dsfmt as d;d.RandomState(1)"
+  - nosetests -vv randomstate
 
 on_success:
   - cd %GIT_DIR%\randomstate


### PR DESCRIPTION
Directly allocate the RNG state which appears to fix the alignment

closes #21