### PR TITLE
FIX: Fix test failures against current NumPy

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -6,7 +6,7 @@ that change the core random number generator.
 What's New or Different
 =======================
 * ``random_uintegers`` produces either 32-bit or 64-bit unsigned integers.
-  These are at thte core of most PRNGs and so they are directly exposed.
+  These are at the core of most PRNGs and so they are directly exposed.
 * ``randomstate.entropy.random_entropy`` provides access to the system
   source of randomness that is used in cryptographic applications (e.g.,
   ``/dev/urandom`` on Unix).
@@ -21,7 +21,7 @@ What's New or Different
 
 Supported Generators
 ====================
-The main innovation is the includion of a number of alterntive pseudo random number
+The main innovation is the inclusion of a number of alternative pseudo random number
 generators, 'in addition' to the standard PRNG in NumPy.  The included PRNGs are:
 
 * MT19937 - The standard NumPy generator.  Produces identical results to NumPy
@@ -39,8 +39,8 @@ generators, 'in addition' to the standard PRNG in NumPy.  The included PRNGs are
   :meth:`randomstate.prng.pcg64.advance`.  PCG-32 only as a period of
   :math:`2^{64}` while PCG-64 has a period of :math:`2^{128}`. See the
   `PCG author's page`_ for more details about this class of PRNG.
-* Multiplicative Lagged Fibbonacci Generator MLFG(1279, 861, \*) - A directly
-  implemented multiplicative lagged fibbonacci generator with a very large
+* Multiplicative Lagged Fibonacci Generator MLFG(1279, 861, \*) - A directly
+  implemented multiplicative lagged Fibonacci generator with a very large
   period and good performance. Future plans include multiple stream support.
   See the `wiki page on Fibonacci generators`_.
 * MRG32K3A - a classic and popular generator by L'Ecuyer. Future plans

--- a/randomstate/array_utilities.pxi
+++ b/randomstate/array_utilities.pxi
@@ -52,7 +52,7 @@ cdef int check_array_constraint(np.ndarray val, object name, constraint_type con
         if np.any(np.less_equal(val, 0)):
             raise ValueError(name + " <= 0")
     elif cons == CONS_BOUNDED_0_1 or cons == CONS_BOUNDED_0_1_NOTNAN:
-        if np.any(np.less_equal(val, 0)) or np.any(np.greater_equal(val, 1)):
+        if np.any(np.less(val, 0)) or np.any(np.greater(val, 1)):
             raise ValueError(name + " <= 0 or " + name + " >= 1")
         if cons == CONS_BOUNDED_0_1_NOTNAN:
             if np.any(np.isnan(val)):

--- a/randomstate/shims/dSFMT/dSFMT.pxi
+++ b/randomstate/shims/dSFMT/dSFMT.pxi
@@ -93,10 +93,10 @@ then an array with that shape is filled and returned.
 
 **No Compatibility Guarantee**
 
-'dSFMT.RandomState' does not make a guarantee that a fixed seed and a
-fixed series of calls to 'dSFMT.RandomState' methods using the same
+``dSFMT.RandomState`` does not make a guarantee that a fixed seed and a
+fixed series of calls to ``dSFMT.RandomState`` methods using the same
 parameters will always produce the same results. This is different from
-'numpy.random.RandomState' guarantee. This is done to simplify improving
+``numpy.random.RandomState`` guarantee. This is done to simplify improving
 random number generators.  To ensure identical results, you must use the
 same release version.
 
@@ -114,9 +114,9 @@ Notes
 -----
 The Python stdlib module "random" also contains a Mersenne Twister
 pseudo-random number generator with a number of methods that are similar
-to the ones available in `RandomState`. `RandomState`, besides being
-NumPy-aware, has the advantage that it provides a much larger number
-of probability distributions to choose from.
+to the ones available in ``RandomState``. The `RandomState` object, besides
+being NumPy-aware, also has the advantage that it provides a much larger
+number of probability distributions to choose from.
 
 **Parallel Features**
 
@@ -138,7 +138,7 @@ segments come from the same sequence.
 .. [1] Mutsuo Saito and Makoto Matsumoto, "SIMD-oriented Fast Mersenne
        Twister: a 128-bit Pseudorandom Number Generator." Monte Carlo
        and Quasi-Monte Carlo Methods 2006, Springer, pp. 607 -- 622, 2008.
-.. [2] Hiroshi Haramoto, Makoto Matsumoto, and Pierre L'Ecuyer, "A Fast
+.. [2] Hiroshi Haramoto, Makoto Matsumoto, and Pierre L\'Ecuyer, "A Fast
        Jump Ahead Algorithm for Linear Recurrences in a Polynomial Space",
        Sequences and Their Applications - SETA, 290--298, 2008.
 """

--- a/randomstate/shims/mlfg-1279-861/mlfg-1279-861.pxi
+++ b/randomstate/shims/mlfg-1279-861/mlfg-1279-861.pxi
@@ -68,9 +68,9 @@ then an array with that shape is filled and returned.
 **No Compatibility Guarantee**
 
 ``mlfg_1279_861.RandomState`` does not make a guarantee that a fixed seed and a
-fixed series of calls to 'mlfg_1279_861.RandomState' methods using the same
+fixed series of calls to ``mlfg_1279_861.RandomState`` methods using the same
 parameters will always produce the same results. This is different from
-'numpy.random.RandomState' guarantee. This is done to simplify improving
+``numpy.random.RandomState`` guarantee. This is done to simplify improving
 random number generators.  To ensure identical results, you must use the
 same release version.
 
@@ -79,10 +79,10 @@ Parameters
 seed : {None, int}, optional
     Random seed initializing the pseudo-random number generator.
     Can be an integer in [0, 2**64] or ``None`` (the default).
-    If ``seed`` is ``None``, then `mlfg_1279_861.RandomState` will try to read
-    entropy from ``/dev/urandom`` (or the Windows analogue) if available to
-    produce a 64-bit seed. If unavailable, the a 64-bit hash of the time
-    (and process ID on Unix) is used.
+    If ``seed`` is ``None``, then ``mlfg_1279_861.RandomState`` will try to
+    read entropy from ``/dev/urandom`` (or the Windows analogue) if available
+    to produce a 64-bit seed. If unavailable, the a 64-bit hash of the time
+    and process ID is used.
 
 Notes
 -----

--- a/randomstate/shims/mrg32k3a/mrg32k3a.pxi
+++ b/randomstate/shims/mrg32k3a/mrg32k3a.pxi
@@ -44,7 +44,7 @@ cdef object _set_state(aug_state *state, object state_info):
 DEF CLASS_DOCSTRING = """
 RandomState(seed=None)
 
-Container for L'Ecuyer MRG32K3A pseudo random number generator.
+Container for L\'Ecuyer MRG32K3A pseudo random number generator.
 
 MRG32K3A is a 32-bit implementation of L'Ecuyer's combined multiple
 recursive generator ([1]_, [2]_). MRG32K3A has a period of 2**191 and
@@ -81,7 +81,7 @@ Notes
 The state of the MRG32KA PRNG is represented by 6 64-bit integers.
 
 This implementation is integer based and produces integers in the interval
-[0, 2**32-209+1].  These are treated as if they 32-bit random integers.
+:math:`[0, 2^{32}-209+1]`.  These are treated as if they 32-bit random integers.
 
 References
 ----------

--- a/randomstate/shims/pcg-32/pcg-32.pxi
+++ b/randomstate/shims/pcg-32/pcg-32.pxi
@@ -41,8 +41,8 @@ RandomState(seed=None)
 Container for the PCG-32 pseudo random number generator.
 
 PCG-32 is a 64-bit implementation of O'Neill's permutation congruential 
-generator ([1]_, [2]_). PCG-32 has a period of 2**64 and supports advancing 
-an arbitrary number of steps as well as 2**63 streams.
+generator ([1]_, [2]_). PCG-32 has a period of :math:`2^64` and supports advancing
+an arbitrary number of steps as well as :math:`2^63` streams.
 
 ``pcg32.RandomState`` exposes a number of methods for generating random
 numbers drawn from a variety of probability distributions. In addition to the
@@ -97,7 +97,7 @@ produce non-overlapping sequences.
 >>> import randomstate.prng.pcg32 as rnd
 >>> rs = [rng.RandomState(1234, 1) for _ in range(10)]
 >>> for i in range(10):
-        rs[i].advance(i * 2**32)
+        rs[i].advance(i * :math:`2^{32}`)
 
 *Note*: Due to the limited period of ``pcg32.RandomState``  using ``advance``
 in parallel applications is not recommended.

--- a/randomstate/shims/pcg-64/pcg-64-docstring.pxi
+++ b/randomstate/shims/pcg-64/pcg-64-docstring.pxi
@@ -4,8 +4,8 @@ RandomState(seed=None)
 Container for the PCG-64 pseudo random number generator.
 
 PCG-64 is a 128-bit implementation of O'Neill's permutation congruential
-generator ([1]_, [2]_). PCG-64 has a period of 2**128 and supports advancing
-an arbitrary number of steps as well as 2**127 streams.
+generator ([1]_, [2]_). PCG-64 has a period of :math:`2^128` and supports advancing
+an arbitrary number of steps as well as :math:`2^127` streams.
 
 ``pcg64.RandomState`` exposes a number of methods for generating random
 numbers drawn from a variety of probability distributions. In addition to the

--- a/randomstate/shims/random-kit/random-kit.pxi
+++ b/randomstate/shims/random-kit/random-kit.pxi
@@ -61,7 +61,7 @@ then an array with that shape is filled and returned.
 **Compatibility Guarantee**
 
 ``mt19937.RandomState`` is identical to ``numpy.random.RandomState`` and
-makes the same compatability guarantee. A fixed seed and a fixed series of
+makes the same compatibility guarantee. A fixed seed and a fixed series of
 calls to ``mt19937.RandomState`` methods using the same parameters will always
 produce the same results up to roundoff error except when the values were
 incorrect. Incorrect values will be fixed and the version in which the fix

--- a/randomstate/shims/xorshift1024/xorshift1024.pxi
+++ b/randomstate/shims/xorshift1024/xorshift1024.pxi
@@ -50,8 +50,8 @@ RandomState(seed=None)
 Container for the xorshift1024* pseudo random number generator.
 
 xorshift1024* is a 64-bit implementation of Saito and Matsumoto's XSadd
-generator [1]_. xorshift1024* has a period of 2**1024 - 1 and
-supports jumping the sequence in increments of 2**512, which allow multiple
+generator [1]_. xorshift1024* has a period of :math:`2^1024 - 1` and
+supports jumping the sequence in increments of :math:`2^512`, which allow multiple
 non-overlapping sequences to be generated.
 
 ``xorshift1024.RandomState`` exposes a number of methods for generating random

--- a/randomstate/shims/xorshift128/xorshift128.pxi
+++ b/randomstate/shims/xorshift128/xorshift128.pxi
@@ -45,8 +45,8 @@ RandomState(seed=None)
 Container for the xorshift128+ pseudo random number generator.
 
 xorshift128+ is a 64-bit implementation of Saito and Matsumoto's XSadd
-generator [1]_. xorshift128+ has a period of 2**128 - 1 and
-supports jumping the sequence in increments of 2**64, which allow multiple
+generator [1]_. xorshift128+ has a period of :math:`2^128 - 1` and
+supports jumping the sequence in increments of :math:`2^64`, which allow multiple
 non-overlapping sequences to be generated.
 
 ``xorshift128.RandomState`` exposes a number of methods for generating random
@@ -78,7 +78,7 @@ seed : {None, int}, optional
 Notes
 -----
 See xorshift1024 for an implementation with a larger period
-(2**1024 - 1) and jump size.
+:math:`2^1024 - 1` and jump size.
 
 **Parallel Features**
 


### PR DESCRIPTION
Update mtrand to latest NumPY
Enable tests that were wrongly skipped
Fix issue wiht NumPy legacy state
Fix constraints for vectors in bernouli
Small typo fixes in the documentation