### PR TITLE
CLN: Remove random uinteger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ install:
 script:
   - nosetests randomstate
   - cd $BUILD_DIR/randomstate
-  - if [ ${PYTHON} = "2.7" ]; then python performance.py; fi
+  - if [ ${PYTHON} = "3.5" ]; then python performance.py; fi

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ argument `dtype`.
 
 * `random_entropy` - Read from the system entropy provider, which is 
 commonly used in cryptographic applications
-* `random_uintegers` - unsigned integers `[0, 2**64-1]`
 * `random_raw` - Direct access to the values produced by the underlying 
 PRNG. The range of the values returned depends on the specifics of the 
 PRNG implementation.

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,6 @@ New Functions
 
 -  ``random_entropy`` - Read from the system entropy provider, which is
    commonly used in cryptographic applications
--  ``random_uintegers`` - unsigned integers ``[0, 2**64-1]``
 -  ``random_raw`` - Direct access to the values produced by the
    underlying PRNG. The range of the values returned depends on the
    specifics of the PRNG implementation.

--- a/doc/source/dsfmt.rst
+++ b/doc/source/dsfmt.rst
@@ -37,7 +37,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,8 +5,6 @@ that change the core random number generator.
 
 What's New or Different
 -----------------------
-* ``random_uintegers`` produces either 32-bit or 64-bit unsigned integers.
-  These are at the core of most PRNGs and so they are directly exposed.
 * ``randomstate.entropy.random_entropy`` provides access to the system
   source of randomness that is used in cryptographic applications (e.g.,
   ``/dev/urandom`` on Unix).

--- a/doc/source/mlfg.rst
+++ b/doc/source/mlfg.rst
@@ -31,7 +31,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/doc/source/mrg32k3a.rst
+++ b/doc/source/mrg32k3a.rst
@@ -38,7 +38,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/doc/source/mt19937.rst
+++ b/doc/source/mt19937.rst
@@ -32,7 +32,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/doc/source/pcg32.rst
+++ b/doc/source/pcg32.rst
@@ -38,7 +38,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/doc/source/pcg64.rst
+++ b/doc/source/pcg64.rst
@@ -38,7 +38,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/doc/source/xoroshiro128plus.rst
+++ b/doc/source/xoroshiro128plus.rst
@@ -38,7 +38,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/doc/source/xorshift1024.rst
+++ b/doc/source/xorshift1024.rst
@@ -38,7 +38,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/doc/source/xorshift128.rst
+++ b/doc/source/xorshift128.rst
@@ -38,7 +38,6 @@ Simple random data
    sample
    choice
    bytes
-   random_uintegers
    random_raw
 
 Permutations

--- a/randomstate/performance.py
+++ b/randomstate/performance.py
@@ -70,20 +70,6 @@ def timer_uniform():
     run_timer(dist, command, None, SETUP, 'Uniforms')
 
 
-def timer_32bit():
-    command = 'rs.{dist}(1000000, bits=32)'
-    command_numpy = 'rs.tomaxint({scale} * 1000000)'.format(scale=scale_32)
-    dist = 'random_uintegers'
-    run_timer(dist, command, command_numpy, SETUP, '32-bit unsigned integers')
-
-
-def timer_64bit():
-    dist = 'random_uintegers'
-    command = 'rs.{dist}(1000000, bits=64)'
-    command_numpy = 'rs.tomaxint({scale} * 1000000)'.format(scale=scale_64)
-    run_timer(dist, command, command_numpy, SETUP, '64-bit unsigned integers')
-
-
 def timer_normal():
     command = 'rs.{dist}(1000000, method="bm")'
     command_numpy = 'rs.{dist}(1000000)'

--- a/randomstate/performance.py
+++ b/randomstate/performance.py
@@ -3,11 +3,13 @@ import struct
 import timeit
 
 import pandas as pd
+import numpy as np
 from numpy.random import RandomState
 
 rs = RandomState()
 
 SETUP = '''
+import numpy as np
 import {mod}.{rng}
 rs = {mod}.{rng}.RandomState()
 rs.random_sample()
@@ -68,6 +70,26 @@ def timer_uniform():
     dist = 'random_sample'
     command = 'rs.{dist}(1000000)'
     run_timer(dist, command, None, SETUP, 'Uniforms')
+
+
+def timer_32bit():
+    info = np.iinfo(np.uint32)
+    min, max = info.min, info.max
+    dist = 'randint'
+    command = 'rs.{dist}({min}, {max}+1, 1000000, dtype=np.uint64)'
+    command = command.format(dist='{dist}', min=min, max=max)
+    command_numpy = command
+    run_timer(dist, command, None, SETUP, '32-bit unsigned integers')
+
+
+def timer_64bit():
+    info = np.iinfo(np.uint64)
+    min, max = info.min, info.max
+    dist = 'randint'
+    command = 'rs.{dist}({min}, {max}+1, 1000000, dtype=np.uint64)'
+    command = command.format(dist='{dist}', min=min, max=max)
+    command_numpy = command
+    run_timer(dist, command, None, SETUP, '64-bit unsigned integers')
 
 
 def timer_normal():

--- a/randomstate/randomstate.pyx
+++ b/randomstate/randomstate.pyx
@@ -601,64 +601,6 @@ cdef class RandomState:
         self.__seed = state['seed']
         self.__stream = state['stream'] if 'stream' in state else None
 
-    def random_uintegers(self, size=None, int bits=64):
-        """
-        random_uintegers(size=None, bits=64)
-
-        Return random unsigned integers
-
-        Parameters
-        ----------
-        size : int or tuple of ints, optional
-            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
-        bits : int {32, 64}
-            Size of the unsigned integer to return, either 32 bit or 64 bit.
-
-        Returns
-        -------
-        out : uint or ndarray
-            Drawn samples.
-
-        Notes
-        -----
-        This method effectively exposes access to the raw underlying
-        pseudo-random number generator since these all produce unsigned
-        integers. In practice these are most useful for generating other
-        random numbers.
-
-        These should not be used to produce bounded random numbers by
-        simple truncation.
-        """
-        cdef uint32_t [:] randoms32
-        cdef uint64_t [:] randoms64
-        cdef aug_state* rng_state
-        cdef Py_ssize_t i, n
-        rng_state = &self.rng_state
-        if bits == 64:
-            if size is None:
-                with self.lock:
-                    return random_uint64(rng_state)
-            n = compute_numel(size)
-            randoms64 = np.empty(n, np.uint64)
-            with self.lock, nogil:
-                for i in range(n):
-                    randoms64[i] = random_uint64(rng_state)
-            return np.asarray(randoms64).reshape(size)
-        elif bits == 32:
-            if size is None:
-                with self.lock:
-                    return random_uint32(rng_state)
-            n = compute_numel(size)
-            randoms32 = np.empty(n, np.uint32)
-            with self.lock, nogil:
-                for i in range(n):
-                    randoms32[i] = random_uint32(rng_state)
-            return np.asarray(randoms32).reshape(size)
-        else:
-            raise ValueError('Unknown value of bits.  Must be either 32 or 64.')
-
     def random_raw(self, size=None):
         """
         random_raw(self, size=None)
@@ -954,7 +896,8 @@ cdef class RandomState:
 
         """
         cdef Py_ssize_t n_uint32 = ((length - 1) // 4 + 1)
-        return self.random_uintegers(n_uint32, bits=32).tobytes()[:length]
+        return self.randint(0, 4294967296, size=n_uint32, dtype=np.uint32).tobytes()[:length]
+
 
     @cython.wraparound(True)
     def choice(self, a, size=None, replace=True, p=None):
@@ -4510,7 +4453,7 @@ permutation = _rand.permutation
 sample = ranf = random = random_sample
 
 random_raw = _rand.random_raw
-random_uintegers = _rand.random_uintegers
+
 
 IF RS_RNG_JUMPABLE:
     jump = _rand.jump

--- a/randomstate/tests/test_direct.py
+++ b/randomstate/tests/test_direct.py
@@ -142,16 +142,6 @@ class Base(object):
                 data.append(long(line.split(',')[-1]))
             return {'seed': seed, 'data': np.array(data, dtype=cls.dtype)}
 
-    def test_raw(self):
-        rs = self.RandomState(*self.data1['seed'])
-        bitsize = 64 if self.bits > 32 else self.bits
-        uints = rs.random_uintegers(1000, bits=bitsize)
-        assert_equal(uints, self.data1['data'])
-
-        rs = self.RandomState(*self.data2['seed'])
-        uints = rs.random_uintegers(1000, bits=bitsize)
-        assert_equal(uints, self.data2['data'])
-
     def test_double(self):
         rs = self.RandomState(*self.data1['seed'])
         vals = uniform_from_uint(self.data1['data'], self.bits)
@@ -271,18 +261,6 @@ class TestMLFG(Base, TestCase):
         cls.data1 = cls._read_csv(join(pwd, './data/mlfg-testset-1.csv'))
         cls.data2 = cls._read_csv(join(pwd, './data/mlfg-testset-2.csv'))
 
-    def test_raw(self):
-        rs = self.RandomState(*self.data1['seed'])
-        vals = uint64_from_uint63(self.data1['data'])
-        bitsize = 64 if self.bits > 32 else self.bits
-        uints = rs.random_uintegers(len(vals), bits=bitsize)
-        assert_equal(uints, vals)
-
-        rs = self.RandomState(*self.data2['seed'])
-        vals = uint64_from_uint63(self.data2['data'])
-        uints = rs.random_uintegers(len(vals), bits=bitsize)
-        assert_equal(uints, vals)
-
 
 class TestDSFMT(Base, TestCase):
     @classmethod
@@ -292,15 +270,6 @@ class TestDSFMT(Base, TestCase):
         cls.dtype = np.uint64
         cls.data1 = cls._read_csv(join(pwd, './data/dSFMT-testset-1.csv'))
         cls.data2 = cls._read_csv(join(pwd, './data/dSFMT-testset-2.csv'))
-
-    def test_raw(self):
-        rs = self.RandomState(*self.data1['seed'])
-        expected = np.array(self.data1['data'] & 0xffffffff, np.uint32)
-        assert_equal(expected, rs.random_uintegers(1000, bits=32))
-
-        rs = self.RandomState(*self.data2['seed'])
-        expected = np.array(self.data2['data'] & 0xffffffff, np.uint32)
-        assert_equal(expected, rs.random_uintegers(1000, bits=32))
 
     def test_double(self):
         rs = self.RandomState(*self.data1['seed'])

--- a/randomstate/tests/test_smoke.py
+++ b/randomstate/tests/test_smoke.py
@@ -97,7 +97,8 @@ class RNG(object):
     def test_init(self):
         rs = self.mod.RandomState()
         state = rs.get_state()
-        rs.random_uintegers(1)
+        rs.standard_normal(1, method='bm')
+        rs.standard_normal(1, method='zig')
         rs.set_state(state)
         new_state = rs.get_state()
         assert_(comp_state(state, new_state))
@@ -118,10 +119,7 @@ class RNG(object):
         else:
             raise SkipTest
 
-    def test_random_uintegers(self):
-        assert_(len(self.rs.random_uintegers(10)) == 10)
-
-    def test_random_uintegers(self):
+    def test_random_raw(self):
         assert_(len(self.rs.random_raw(10)) == 10)
         assert_(self.rs.random_raw((10,10)).shape == (10,10))
 
@@ -179,9 +177,9 @@ class RNG(object):
 
     def test_reset_state(self):
         state = self.rs.get_state()
-        int_1 = self.rs.random_uintegers(1)
+        int_1 = self.rs.random_raw(1)
         self.rs.set_state(state)
-        int_2 = self.rs.random_uintegers(1)
+        int_2 = self.rs.random_raw(1)
         assert_(int_1 == int_2)
 
     def test_entropy_init(self):
@@ -208,12 +206,12 @@ class RNG(object):
 
     def test_reset_state_uint32(self):
         rs = self.mod.RandomState(*self.seed)
-        rs.random_uintegers(bits=32)
+        rs.randint(0, 2 ** 24, dtype=np.uint32)
         state = rs.get_state()
-        n1 = rs.random_uintegers(bits=32, size=10)
+        n1 = rs.randint(0, 2**24, 10, dtype=np.uint32)
         rs2 = self.mod.RandomState()
         rs2.set_state(state)
-        n2 = rs2.random_uintegers(bits=32, size=10)
+        n2 = rs.randint(0, 2**24, 10, dtype=np.uint32)
         assert_((n1 == n2).all())
 
     def test_shuffle(self):


### PR DESCRIPTION
Remove random integer since it is redundant (`randint`) can produce the identical sequence, and `random_raw` provides better access to raw values.