### PR TITLE
Generated samples by this Ziggurat implementation is not normally-distributed

### DIFF
--- a/randomstate/distributions.c
+++ b/randomstate/distributions.c
@@ -141,8 +141,6 @@ static inline double gauss_zig_double(aug_state* state)
         x = rabs * wi_double[idx];
         if (sign & 0x1)
             x = -x;
-        if (r & 0x1)
-            x = -x;
         if (rabs < ki_double[idx])
             return x;  // # 99.3% of the time return here
         if (idx == 0)


### PR DESCRIPTION
![untitled 2016-09-30 07-41-21](https://cloud.githubusercontent.com/assets/1067855/18974897/5468aab6-86e1-11e6-88f6-0b794bbbbbfd.png)
The current Ziggurat implementation from 1.11.3 never generates negative samples,
unless the sample falls in the tail of normal distribution.
That results in a funny distribution graph as shown in the above figure.
This PR fixes that.