### PR TITLE
Allow output arrays to be passed to some methods

### DIFF
--- a/randomstate/array_fillers.pxi.in
+++ b/randomstate/array_fillers.pxi.in
@@ -25,6 +25,16 @@ cdef object {{ctype}}_fill(aug_state* state, void *func, object size, object loc
             out_array = <np.ndarray>size;
             if out_array.dtype.type is not np.{{nptype}}:
                 raise TypeError("array given for size is not {{nptype}}")
+
+            # checking out_array.flags.farray can produce the wrong answer
+            #
+            # - eg `numpy.zeros( (5, 5, 5) ).transpose( (2, 0, 1) ).flags.farray` should be
+            #   False as f_contiguous and c_contiguous are False, but on numpy 0.11.2 it
+            #   is True
+            #
+            elif not (out_array.flags.behaved and (out_array.flags.c_contiguous or
+                                                   out_array.flags.f_contiguous)):
+                raise TypeError("array is not well behaved and contiguous")
         else:
             out_array = <np.ndarray>np.empty(size, np.{{nptype}})
 

--- a/randomstate/array_fillers.pxi.in
+++ b/randomstate/array_fillers.pxi.in
@@ -21,7 +21,13 @@ cdef object {{ctype}}_fill(aug_state* state, void *func, object size, object loc
             f(state, 1, &out)
         return out
     else:
-        out_array = <np.ndarray>np.empty(size, np.{{nptype}})
+        if isinstance(size, np.ndarray):
+            out_array = <np.ndarray>size;
+            if out_array.dtype.type is not np.{{nptype}}:
+                raise TypeError("array given for size is not {{nptype}}")
+        else:
+            out_array = <np.ndarray>np.empty(size, np.{{nptype}})
+
         n = np.PyArray_SIZE(out_array)
         out_array_data = <{{ctype}} *>np.PyArray_DATA(out_array)
         with lock, nogil:


### PR DESCRIPTION
This patch allows us to pass a target array (as the `size`) parameter to methods that produce floats or doubles, such as `standard_normal` for example.
### Motivation

The motivation here is as follows.  Suppose we wish to populate an _existing_ large array (or perhaps a large slice of that large array) with a random standard normal sample.  Then currently we would do so as follows:

```
# suppose `a` is an existing large 20 x 1000000 array
a[2] = randomstate.standard_normal( (1000000,) )
```

Under the hood:
- randomstate will allocate a large (empty) target array;
- it will be populated from the generator;
- that data must be copied into the large target array;

With these changes, instead we can use:

```
# suppose `a` is an existing large 20 x 1000000 array
randomstate.standard_normal(a[2])
```

Under the hood:
- `a[2]` is populated from the generator;
### A Concrete Example

Suppose we have independent number generators.  For `pcg` these may be different streams, or for `dsfmt` we can `jump` the stream.  Then we can speed up the generation of very large random arrays by using a thread pool to fill slices of that array.

Without this patch, the best we can do is fill smaller arrays with random numbers and then concatenate them into a large array.  However for very large arrays we incur twice the memory overhead and the concatenation cost swallows much of the time savings.

With this patch, we can instead allocate a large target array and fill slices of it.
### Results:

Generating an array of 16,000,000 standard normals using `dsfmt`
- using eg `randomstate.prng.dsfmt.RandomState().standard_normal( (16000000,) )` **147ms**
- using four threads (via `concurrent.futures`) and concatenating the result **96ms**
- applying this patch and using four threads to fill subviews **58ms**
