### PR TITLE
SYNC: Synchronize with changes in NumPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ matrix:
     - CYTHON=0.23
   - env:
     - PYTHON=3.5
-
+  - env:
+    - PYTHON=3.6
+    
 before_install:
   - if [ ${TRAVIS_OS_NAME} = "osx" ]; then wget https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
   - if [ ${TRAVIS_OS_NAME} = "linux" ]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh; fi

--- a/randomstate/randomstate.pyx
+++ b/randomstate/randomstate.pyx
@@ -1187,7 +1187,7 @@ cdef class RandomState:
         Py_INCREF(temp)  # needed to get around Pyrex's automatic reference-counting
                          # rules because EnsureArray steals a reference
         arange = <np.ndarray>np.PyArray_EnsureArray(temp)
-        if not np.isfinite(arange).all():
+        if not np.all(np.isfinite(arange)):
             raise OverflowError('Range exceeds valid bounds')
         return cont(&self.rng_state, &random_uniform, size, self.lock, 2,
                     alow, '', CONS_NONE,
@@ -2287,7 +2287,7 @@ cdef class RandomState:
         a good estimate of the true mean.
 
         The derivation of the t-distribution was first published in
-        1908 by William Gisset while working for the Guinness Brewery
+        1908 by William Gosset while working for the Guinness Brewery
         in Dublin. Due to proprietary issues, he had to publish under
         a pseudonym, and so he used the name Student.
 

--- a/randomstate/tests/tests_numpy_mt19937.py
+++ b/randomstate/tests/tests_numpy_mt19937.py
@@ -810,6 +810,8 @@ class TestRandomDist(TestCase):
         assert_raises(OverflowError, func, -np.inf, 0)
         assert_raises(OverflowError, func,  0,      np.inf)
         assert_raises(OverflowError, func,  fmin,   fmax)
+        assert_raises(OverflowError, func, [-np.inf], [0])
+        assert_raises(OverflowError, func, [0], [np.inf])
 
         # (fmax / 1e17) - fmin is within range, so this should not throw
         mt19937.uniform(low=fmin, high=fmax / 1e17)


### PR DESCRIPTION
Synchronize with recent docstring changes in NumPy
Add missing test
Stat testing on Python 3.6

Updates to include numpy/numpy#8227 and numpy/numpy#8374