### PR TITLE
BUG: Stricter check for output arrays

### DIFF
--- a/randomstate/array_fillers.pxi.in
+++ b/randomstate/array_fillers.pxi.in
@@ -26,9 +26,9 @@ cdef object {{ctype}}_fill(aug_state* state, void *func, object size, object loc
         if out_array.dtype != np.{{nptype}}:
             raise TypeError('Supplied output array has the wrong type.'
                              'Expected {{nptype}}, got {0}'.format(out_array.dtype))
-        if not (np.PyArray_CHKFLAGS(out_array, np.NPY_C_CONTIGUOUS) or
-                np.PyArray_CHKFLAGS(out_array, np.NPY_F_CONTIGUOUS)):
-            raise ValueError('Supplied output array is not C contiguous')
+        if not (np.PyArray_CHKFLAGS(out_array, np.NPY_CARRAY) or
+                np.PyArray_CHKFLAGS(out_array, np.NPY_FARRAY)):
+            raise ValueError('Supplied output array is not contiguous, writable or aligned.')
         if size is not None:
             # TODO: enable this !!! if tuple(size) != out_array.shape:
             raise ValueError('size and shape of the supplied output are different')

--- a/randomstate/tests/test_smoke.py
+++ b/randomstate/tests/test_smoke.py
@@ -632,6 +632,13 @@ class RNG(object):
         direct = rs.standard_exponential(size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
+    def test_output_fill_error(self):
+        rs = self.rs
+        size = (31, 7, 97)
+        existing = np.empty(size)
+        assert_raises(TypeError, rs.standard_normal, out=existing, dtype=np.float32)
+        assert_raises(ValueError, rs.standard_normal, out=existing[::3])
+
 
 class TestMT19937(RNG):
     @classmethod


### PR DESCRIPTION
Ensure output arrays are contiguous and well behaved