### PR TITLE
BLD: Avoid unnecessary recompilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,6 +215,9 @@ else:
     files = glob.glob('./randomstate/*.in')
     for templated_file in files:
         output_file_name = os.path.splitext(templated_file)[0]
+        if (os.path.exists(output_file_name) and
+                (os.path.getmtime(templated_file) < os.path.getmtime(output_file_name))):
+            continue
         with open(templated_file, 'r') as source_file:
             template = tempita.Template(source_file.read())
         with open(output_file_name, 'w') as output_file:


### PR DESCRIPTION
Only run templates if underlying files have changed